### PR TITLE
fix: canonicalize paths in validate_workspace_path to prevent potential directory traversal

### DIFF
--- a/src/executor.mbt
+++ b/src/executor.mbt
@@ -2502,6 +2502,26 @@ fn parse_bool_false_default(value : String) -> Bool {
 }
 
 ///|
+/// Resolve `.` and `..` segments in an absolute path.
+fn canonicalize_abs_path(path : String) -> String {
+  let parts : Array[String] = []
+  for part_view in path.split("/") {
+    let part = part_view.to_string()
+    if part.length() == 0 || part == "." {
+      continue
+    }
+    if part == ".." {
+      if parts.length() > 0 {
+        ignore(parts.pop())
+      }
+      continue
+    }
+    parts.push(part)
+  }
+  "/" + parts.join("/")
+}
+
+///|
 /// Validate that a user-provided path stays within the workspace.
 /// Returns the resolved absolute path, or None if it escapes.
 fn validate_workspace_path(
@@ -2509,8 +2529,10 @@ fn validate_workspace_path(
   user_path : String,
 ) -> String? {
   let resolved = resolve_task_cwd(workspace_root, user_path)
-  let resolved_abs = absolute_exec_path(resolved)
-  let workspace_abs = absolute_exec_path(resolve_task_cwd(workspace_root, ""))
+  let resolved_abs = canonicalize_abs_path(absolute_exec_path(resolved))
+  let workspace_abs = canonicalize_abs_path(
+    absolute_exec_path(resolve_task_cwd(workspace_root, "")),
+  )
   if resolved_abs == workspace_abs ||
     resolved_abs.has_prefix(workspace_abs + "/") {
     Some(resolved_abs)

--- a/src/executor_wbtest.mbt
+++ b/src/executor_wbtest.mbt
@@ -80,3 +80,37 @@ test "is_commit_sha: too short hex string is not a SHA" {
 test "is_commit_sha: empty string is not a SHA" {
   assert_eq(is_commit_sha(""), false)
 }
+
+///|
+test "canonicalize_abs_path: resolves parent segments" {
+  inspect(canonicalize_abs_path("/a/b/../c"), content="/a/c")
+  inspect(canonicalize_abs_path("/a/b/../../c"), content="/c")
+  inspect(canonicalize_abs_path("/a/./b/./c"), content="/a/b/c")
+  inspect(canonicalize_abs_path("/a/b/c/../../d"), content="/a/d")
+}
+
+///|
+test "canonicalize_abs_path: stops at root" {
+  inspect(canonicalize_abs_path("/a/../../../.."), content="/")
+}
+
+///|
+test "validate_workspace_path: rejects traversal with leading dotdot" {
+  assert_eq(validate_workspace_path("/home/user/workspace", "../../etc"), None)
+}
+
+///|
+test "validate_workspace_path: rejects traversal with intermediate dotdot" {
+  assert_eq(
+    validate_workspace_path("/home/user/workspace", "sub/../../.."),
+    None,
+  )
+}
+
+///|
+test "validate_workspace_path: accepts legitimate subpath" {
+  assert_ne(
+    validate_workspace_path("/home/user/workspace", "subdir/file.txt"),
+    None,
+  )
+}


### PR DESCRIPTION
### Changes

- `validate_workspace_path()` compared raw uncanonicalized paths, allowing inputs like `sub/../../..` to pass the prefix check while escaping the workspace at the OS level
- Added `canonicalize_abs_path()` to resolve `.` and `..` segments before the comparison (string-only; no symlink resolution)
- Added whitebox tests covering traversal rejection and legitimate subpath acceptance

Fixes #7.