### PR TITLE
Support !cancelled() in runs.post-if and runs.pre-if

### DIFF
--- a/src/core/parser.mbt
+++ b/src/core/parser.mbt
@@ -1753,11 +1753,11 @@ fn parse_action_manifest_yaml(text : String) -> ActionManifestParseResult {
   if action_using == "docker" && image.length() == 0 {
     errors.push("runs.image is required")
   }
-  if pre_if != "always()" && pre_if != "success()" {
-    errors.push("runs.pre-if must be success() or always() in MVP")
+  if pre_if != "always()" && pre_if != "success()" && pre_if != "!cancelled()" {
+    errors.push("runs.pre-if must be success(), always(), or !cancelled() in MVP")
   }
-  if post_if != "always()" && post_if != "success()" {
-    errors.push("runs.post-if must be success() or always() in MVP")
+  if post_if != "always()" && post_if != "success()" && post_if != "!cancelled()" {
+    errors.push("runs.post-if must be success(), always(), or !cancelled() in MVP")
   }
   if errors.length() > 0 {
     { action: None, errors }

--- a/src/lib_test.mbt
+++ b/src/lib_test.mbt
@@ -2693,3 +2693,54 @@ test "security: skip pattern does not match partial action names incorrectly" {
     content="false",
   )
 }
+
+///|
+test "parser: post-if !cancelled() is accepted" {
+  let src =
+    #|name: Setup Gradle
+    #|runs:
+    #|  using: node20
+    #|  main: main.js
+    #|  post: post.js
+    #|  post-if: '!cancelled()'
+  let parsed = parse_local_action_yaml(src)
+  // Only the composite restriction error, not a post-if error
+  inspect(
+    parsed.errors,
+    content="[\"only composite local actions are supported in MVP\"]",
+  )
+}
+
+///|
+test "parser: pre-if !cancelled() is accepted" {
+  let src =
+    #|name: Setup Gradle
+    #|runs:
+    #|  using: node20
+    #|  main: main.js
+    #|  pre: pre.js
+    #|  pre-if: '!cancelled()'
+  let parsed = parse_local_action_yaml(src)
+  // Only the composite restriction error, not a pre-if error
+  inspect(
+    parsed.errors,
+    content="[\"only composite local actions are supported in MVP\"]",
+  )
+}
+
+///|
+test "parser: post-if failure() is rejected" {
+  let src =
+    #|name: Setup Gradle
+    #|runs:
+    #|  using: node20
+    #|  main: main.js
+    #|  post: post.js
+    #|  post-if: failure()
+  let parsed = parse_local_action_yaml(src)
+  // Both post-if error and composite restriction error
+  inspect(
+    parsed.errors.iter().any(fn(e) { e.contains("post-if") }),
+    content="true",
+  )
+}

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -1812,11 +1812,11 @@ fn parse_action_manifest_yaml(text : String) -> ActionManifestParseResult {
   if action_using == "docker" && image.length() == 0 {
     errors.push("runs.image is required")
   }
-  if pre_if != "always()" && pre_if != "success()" {
-    errors.push("runs.pre-if must be success() or always() in MVP")
+  if pre_if != "always()" && pre_if != "success()" && pre_if != "!cancelled()" {
+    errors.push("runs.pre-if must be success(), always(), or !cancelled() in MVP")
   }
-  if post_if != "always()" && post_if != "success()" {
-    errors.push("runs.post-if must be success() or always() in MVP")
+  if post_if != "always()" && post_if != "success()" && post_if != "!cancelled()" {
+    errors.push("runs.post-if must be success(), always(), or !cancelled() in MVP")
   }
   if errors.length() > 0 {
     { action: None, errors }


### PR DESCRIPTION
Some actions like `gradle/actions/setup-gradle` use `post-if: '!cancelled()'` in their `action.yml` (e.g. [setup-gradle/action.yml#L245](https://github.com/gradle/actions/blob/03ee1e1693f571d64506b3ed4cdf120520300ff2/setup-gradle/action.yml#L245)), but actrun only allowed `success()` and `always()`, causing these workflows to fail. Since actrun has no concept of cancellation, `!cancelled()` is always `true` and equivalent to `always()`.

## How to reproduce

```
/path/to/work
├── .github
│   └── workflows
│       └── ci.yml
└── my-action
    ├── action.yml
    ├── main.js
    └── post.js
```

```
$ cat .github/workflows/ci.yml
name: CI (!cancelled() example)

on:
  push:

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
      - uses: ./my-action
```

```
$ cat my-action/action.yml
name: My Action
description: Demo action with post-if !cancelled()
runs:
  using: node20
  main: main.js
  post: post.js
  post-if: '!cancelled()'

$ cat my-action/main.js
console.log("main: running");

$ cat my-action/post.js
console.log("post: cleanup");
```

```bash
$ cd /path/to/work
$ actrun .github/workflows/ci.yml --trust --local
```

## Before fix

```
error: step 'build/step_1' local action 'my-action/action.yml' runs.post-if must be success() or always() in MVP
```

## After fix

```
run_id=run-1
workflow=CI (!cancelled() example)
state=completed
build/step_1: success
build/step_2: success
build/step_2__post: success
build/__finish: success
```
