### PR TITLE
fix: make --nix flag actually force nix-shell wrapping

### DIFF
--- a/src/executor.mbt
+++ b/src/executor.mbt
@@ -36,6 +36,9 @@ async fn detect_nix_config(
   if @xfs.path_exists(workspace_root + "/shell.nix") {
     return Shell
   }
+  if nix_mode == "auto" {
+    return Shell
+  }
   NixNone
 }
 


### PR DESCRIPTION
`--nix` sets `nix_mode` to `"auto"`, but `detect_nix_config` didn't handle it — falling through to `NixNone` when no `flake.nix`/`shell.nix` exists. Now falls back to `Shell` mode (bare `nix-shell --run`).