### PR TITLE
fix: propagate composite action outputs to steps context

### DIFF
--- a/src/compat_docs_test.mbt
+++ b/src/compat_docs_test.mbt
@@ -2307,3 +2307,22 @@ test "compat docs: parse push paths-ignore fixture" {
     content="true",
   )
 }
+
+///|
+#cfg(target="native")
+async test "compat docs: composite action outputs propagated to steps context" {
+  let (fixture, workflow, workspace) = compat_prepare_suite_fixture_auto(
+    compat_docs_suite(),
+    "composite-action-output",
+    copy_fixture=true,
+  )
+  let lowered = lower_push_workflow_in_workspace(workflow, workspace)
+  let report = execute_lowered_native(lowered, workspace_root=workspace)
+  let task = compat_expect_task_report(report, "test/check")
+
+  inspect(fixture.id, content="docs-composite-action-output")
+  inspect(lowered.errors, content="[]")
+  inspect(report.ok, content="true")
+  inspect(task.status, content="success")
+  inspect(task.stdout, content="hello")
+}

--- a/src/executor.mbt
+++ b/src/executor.mbt
@@ -280,6 +280,81 @@ fn append_paths(newer : Array[String], older : Array[String]) -> Array[String] {
 }
 
 ///|
+fn apply_composite_output_mappings(
+  state : JobRuntimeState,
+  step_id : String,
+  mappings : Map[String, Map[String, String]],
+) -> JobRuntimeState {
+  // Check all composite output mappings to see if this step_id is a composite
+  // inner step that completes a composite action's last step.
+  // step_id format for composite inner steps: "outer__inner"
+  // We need to find the outer_step_id and check if it has output mappings.
+  let mut outer_step_id = ""
+  let mut idx = step_id.length()
+  while idx >= 2 {
+    idx -= 1
+    if idx > 0 &&
+      step_id.unsafe_get(idx - 1) == '_'.to_int().to_uint16() &&
+      step_id.unsafe_get(idx) == '_'.to_int().to_uint16() {
+      outer_step_id = exec_text_slice(step_id, 0, idx - 1)
+      break
+    }
+  }
+  if outer_step_id.length() == 0 {
+    return state
+  }
+  guard mappings.get(outer_step_id) is Some(output_map) else { return state }
+  // Resolve each output mapping: "composite_step_id:output_key" → value
+  let outer_outputs : Map[String, String] = state.step_outputs
+    .get(outer_step_id)
+    .unwrap_or({})
+  for output_name, encoded in output_map {
+    // encoded format: "outer__inner:key"
+    guard find_colon(encoded) is Some(colon_idx) else { continue }
+    let source_step = exec_text_slice(encoded, 0, colon_idx)
+    let source_key = exec_text_slice(encoded, colon_idx + 1, encoded.length())
+    match state.step_outputs.get(source_step) {
+      Some(source_outputs) =>
+        match source_outputs.get(source_key) {
+          Some(value) => outer_outputs[output_name] = value
+          None => ()
+        }
+      None => ()
+    }
+  }
+  if outer_outputs.length() == 0 {
+    return state
+  }
+  let updated_outputs : Map[String, Map[String, String]] = {}
+  for key, value in state.step_outputs {
+    updated_outputs[key] = value
+  }
+  updated_outputs[outer_step_id] = outer_outputs
+  {
+    env_updates: state.env_updates,
+    path_entries: state.path_entries,
+    step_outputs: updated_outputs,
+    step_outcomes: state.step_outcomes,
+    step_conclusions: state.step_conclusions,
+    action_states: state.action_states,
+    started_action_scopes: state.started_action_scopes,
+  }
+}
+
+///|
+fn find_colon(text : String) -> Int? {
+  let target = ':'.to_int().to_uint16()
+  let mut idx = 0
+  while idx < text.length() {
+    if text.unsafe_get(idx) == target {
+      return Some(idx)
+    }
+    idx += 1
+  }
+  None
+}
+
+///|
 fn apply_job_runtime_updates(
   state : JobRuntimeState,
   step_id : String,
@@ -4312,7 +4387,7 @@ pub async fn execute_lowered_native(
               }
               let outcome = task_outcome(report)
               let conclusion = task_conclusion(outcome, continue_on_error)
-              let next_state = apply_job_runtime_updates(
+              let mut next_state = apply_job_runtime_updates(
                 current_state,
                 plan.step_id,
                 Some(outcome),
@@ -4322,6 +4397,11 @@ pub async fn execute_lowered_native(
                 result.path_entries,
                 result.output_values,
                 result.state_updates,
+              )
+              next_state = apply_composite_output_mappings(
+                next_state,
+                plan.step_id,
+                lowered.plan.composite_output_mappings,
               )
               job_states[plan.job_id] = next_state
               if conclusion == "success" {

--- a/src/lib.mbt
+++ b/src/lib.mbt
@@ -627,6 +627,7 @@ pub struct ExecutionPlan {
   job_matrix_fail_fast : Map[String, Bool]
   job_containers : Map[String, JobContainerSpec]
   job_services : Map[String, Map[String, JobContainerSpec]]
+  composite_output_mappings : Map[String, Map[String, String]]
 }
 
 ///|
@@ -656,6 +657,7 @@ pub struct WorkflowParseResult {
 pub struct LocalActionSpec {
   name : String
   inputs : Map[String, String]
+  outputs : Map[String, String]
   steps : Array[StepSpec]
 }
 
@@ -664,8 +666,9 @@ pub fn new_local_action(
   steps : Array[StepSpec],
   name? : String = "",
   inputs? : Map[String, String] = {},
+  outputs? : Map[String, String] = {},
 ) -> LocalActionSpec {
-  { name, inputs, steps }
+  { name, inputs, outputs, steps }
 }
 
 ///|

--- a/src/lowering.mbt
+++ b/src/lowering.mbt
@@ -2095,6 +2095,7 @@ fn lower_manifest_backed_action(
   task_plans : Array[TaskPlan],
   deferred_post_tasks : Array[DeferredActionTask],
   errors : Array[String],
+  composite_output_mappings? : Map[String, Map[String, String]] = {},
 ) -> String {
   guard find_local_action_manifest(workspace_root, cached_root)
     is Some((_, manifest_text)) else {
@@ -2129,6 +2130,7 @@ fn lower_manifest_backed_action(
       deferred_post_tasks,
       errors,
       action_context_env~,
+      composite_output_mappings~,
     )
   }
   if action_manifest.runtime.has_prefix("node") {
@@ -2440,6 +2442,7 @@ fn lower_local_action(
   deferred_post_tasks : Array[DeferredActionTask],
   errors : Array[String],
   action_context_env? : Map[String, String] = {},
+  composite_output_mappings? : Map[String, Map[String, String]] = {},
 ) -> String {
   if workspace_root.length() == 0 {
     errors.push(
@@ -2473,14 +2476,27 @@ fn lower_local_action(
       join_path(workspace_root, action_path_root),
     )
     return lower_manifest_backed_action(
-      workflow, job, job_env, outer_step, outer_step_id, previous_task_id, local_action_ref,
-      abs_action_root, workspace_root, tasks, task_plans, deferred_post_tasks, errors,
+      workflow,
+      job,
+      job_env,
+      outer_step,
+      outer_step_id,
+      previous_task_id,
+      local_action_ref,
+      abs_action_root,
+      workspace_root,
+      tasks,
+      task_plans,
+      deferred_post_tasks,
+      errors,
+      composite_output_mappings~,
     )
   }
   let action = new_local_action(
     action_manifest.steps,
     name=action_manifest.name,
     inputs=action_manifest.inputs,
+    outputs=action_manifest.outputs,
   )
 
   let mut local_previous_task_id = previous_task_id
@@ -2555,6 +2571,7 @@ fn lower_local_action(
             deferred_post_tasks,
             errors,
             action_context_env~,
+            composite_output_mappings~,
           )
           inner_index += 1
           continue
@@ -2596,9 +2613,20 @@ fn lower_local_action(
       }
       if manifest_backed_action_root(action_ref) is Some(cached_root) {
         local_previous_task_id = lower_manifest_backed_action(
-          workflow, job, outer_env, nested_outer_step, resolved_step_id, local_previous_task_id,
-          action_ref, cached_root, workspace_root, tasks, task_plans, deferred_post_tasks,
+          workflow,
+          job,
+          outer_env,
+          nested_outer_step,
+          resolved_step_id,
+          local_previous_task_id,
+          action_ref,
+          cached_root,
+          workspace_root,
+          tasks,
+          task_plans,
+          deferred_post_tasks,
           errors,
+          composite_output_mappings~,
         )
         inner_index += 1
         continue
@@ -2665,7 +2693,58 @@ fn lower_local_action(
     local_previous_task_id = task_id
     inner_index += 1
   }
+  // Register composite action output mappings
+  // outputs map: output_name → expression (e.g., "${{ steps.write.outputs.value }}")
+  // We resolve inner step references relative to the outer step scope
+  if action.outputs.length() > 0 {
+    let resolved_outputs : Map[String, String] = {}
+    for output_name, expression in action.outputs {
+      // Rewrite inner step references to composite step IDs
+      // e.g., "steps.write.outputs.value" → look up "outer__write" in step_outputs
+      resolved_outputs[output_name] = resolve_composite_output_expression(
+        expression, outer_step_id,
+      )
+    }
+    composite_output_mappings[outer_step_id] = resolved_outputs
+  }
   local_previous_task_id
+}
+
+///|
+fn resolve_composite_output_expression(
+  expression : String,
+  outer_step_id : String,
+) -> String {
+  // Parse "${{ steps.<inner_id>.outputs.<key> }}" and return "outer__inner:key"
+  // as a compact representation the executor can resolve
+  let trimmed = expression.trim(chars=" \t\n\r").to_string()
+  let prefix = "${{"
+  let suffix = "}}"
+  guard trimmed.has_prefix(prefix) && trimmed.has_suffix(suffix) else {
+    return expression
+  }
+  let inner = text_slice(
+      trimmed,
+      prefix.length(),
+      trimmed.length() - suffix.length(),
+    )
+    .trim(chars=" \t\n\r")
+    .to_string()
+  let steps_prefix = "steps."
+  guard inner.has_prefix(steps_prefix) else { return expression }
+  let rest = text_slice(inner, steps_prefix.length(), inner.length())
+  let outputs_marker = ".outputs."
+  guard find_substring(rest, outputs_marker, 0) is Some(dot_idx) else {
+    return expression
+  }
+  let inner_step_id = text_slice(rest, 0, dot_idx)
+  let output_key = text_slice(
+    rest,
+    dot_idx + outputs_marker.length(),
+    rest.length(),
+  )
+  let composite_id = composite_step_id(outer_step_id, inner_step_id)
+  composite_id + ":" + output_key
 }
 
 ///|
@@ -2687,6 +2766,7 @@ pub fn lower_push_workflow_in_workspace(
   let job_matrix_fail_fast : Map[String, Bool] = {}
   let job_containers : Map[String, JobContainerSpec] = {}
   let job_services : Map[String, Map[String, JobContainerSpec]] = {}
+  let composite_output_mappings : Map[String, Map[String, String]] = {}
   let entry_targets : Array[String] = []
   let seen_jobs : Map[String, Bool] = {}
   if workflow.workflow_call {
@@ -2812,8 +2892,19 @@ pub fn lower_push_workflow_in_workspace(
         match action_ref {
           LocalPath(path) => {
             previous_task_id = lower_local_action(
-              workflow, job, job_env, step, resolved_step_id, previous_task_id, path,
-              workspace_root, tasks, task_plans, deferred_post_tasks, errors,
+              workflow,
+              job,
+              job_env,
+              step,
+              resolved_step_id,
+              previous_task_id,
+              path,
+              workspace_root,
+              tasks,
+              task_plans,
+              deferred_post_tasks,
+              errors,
+              composite_output_mappings~,
             )
             step_index += 1
             continue
@@ -2845,9 +2936,20 @@ pub fn lower_push_workflow_in_workspace(
         if workspace_root.length() > 0 &&
           manifest_backed_action_root(action_ref) is Some(cached_root) {
           previous_task_id = lower_manifest_backed_action(
-            workflow, job, job_env, step, resolved_step_id, previous_task_id, action_ref,
-            cached_root, workspace_root, tasks, task_plans, deferred_post_tasks,
+            workflow,
+            job,
+            job_env,
+            step,
+            resolved_step_id,
+            previous_task_id,
+            action_ref,
+            cached_root,
+            workspace_root,
+            tasks,
+            task_plans,
+            deferred_post_tasks,
             errors,
+            composite_output_mappings~,
           )
           step_index += 1
           continue
@@ -2943,6 +3045,7 @@ pub fn lower_push_workflow_in_workspace(
       job_matrix_fail_fast,
       job_containers,
       job_services,
+      composite_output_mappings,
     },
     errors,
   }

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -1651,9 +1651,39 @@ fn parse_local_action_inputs(
 }
 
 ///|
+fn parse_action_outputs(
+  value : YamlValue?,
+  errors : Array[String],
+  ctx : String,
+) -> Map[String, String] {
+  let outputs : Map[String, String] = {}
+  guard value is Some(actual) else { return outputs }
+  match actual {
+    Obj(fields) =>
+      for field in fields {
+        match field.value {
+          Obj(output_fields) =>
+            outputs[field.key] = yaml_as_optional_string(
+              yaml_obj_get(output_fields, "value"),
+              errors,
+              ctx + "." + field.key + ".value",
+            ).unwrap_or("")
+          Str(text) => outputs[field.key] = text
+          Null => outputs[field.key] = ""
+          _ =>
+            errors.push(ctx + "." + field.key + " must be a mapping or string")
+        }
+      }
+    _ => errors.push(ctx + " must be a mapping")
+  }
+  outputs
+}
+
+///|
 priv struct ActionManifestSpec {
   name : String
   inputs : Map[String, String]
+  outputs : Map[String, String]
   runtime : String
   steps : Array[StepSpec]
   main : String
@@ -1732,6 +1762,11 @@ fn parse_action_manifest_yaml(text : String) -> ActionManifestParseResult {
     yaml_obj_get(root_fields, "inputs"),
     errors,
     "inputs",
+  )
+  let outputs = parse_action_outputs(
+    yaml_obj_get(root_fields, "outputs"),
+    errors,
+    "outputs",
   )
   let runs_fields = match yaml_obj_get(root_fields, "runs") {
     Some(runs_value) => yaml_as_obj(runs_value, errors, "runs")
@@ -1831,6 +1866,7 @@ fn parse_action_manifest_yaml(text : String) -> ActionManifestParseResult {
       action: Some({
         name,
         inputs,
+        outputs,
         runtime: action_using,
         steps,
         main,
@@ -1867,7 +1903,12 @@ pub fn parse_local_action_yaml(text : String) -> LocalActionParseResult {
   } else {
     {
       action: Some(
-        new_local_action(action.steps, name=action.name, inputs=action.inputs),
+        new_local_action(
+          action.steps,
+          name=action.name,
+          inputs=action.inputs,
+          outputs=action.outputs,
+        ),
       ),
       errors,
     }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -59,7 +59,7 @@ pub fn new_job_container_spec(String, credentials? : JobContainerCredentialsSpec
 
 pub fn new_job_matrix(Array[Map[String, String]], fail_fast? : Bool, max_parallel? : Int?) -> JobMatrixSpec
 
-pub fn new_local_action(Array[StepSpec], name? : String, inputs? : Map[String, String]) -> LocalActionSpec
+pub fn new_local_action(Array[StepSpec], name? : String, inputs? : Map[String, String], outputs? : Map[String, String]) -> LocalActionSpec
 
 pub fn new_permissions_spec(values? : Map[String, String]) -> PermissionsSpec
 
@@ -173,6 +173,7 @@ pub struct ExecutionPlan {
   job_matrix_fail_fast : Map[String, Bool]
   job_containers : Map[String, JobContainerSpec]
   job_services : Map[String, Map[String, JobContainerSpec]]
+  composite_output_mappings : Map[String, Map[String, String]]
 }
 
 pub struct GitHubActionPrefetchResult {
@@ -232,6 +233,7 @@ pub struct LocalActionParseResult {
 pub struct LocalActionSpec {
   name : String
   inputs : Map[String, String]
+  outputs : Map[String, String]
   steps : Array[StepSpec]
 }
 

--- a/testdata/docs/composite-action-output/.github/actions/emit/action.yml
+++ b/testdata/docs/composite-action-output/.github/actions/emit/action.yml
@@ -1,0 +1,10 @@
+name: emit
+outputs:
+  value:
+    value: ${{ steps.write.outputs.value }}
+runs:
+  using: composite
+  steps:
+    - id: write
+      shell: bash
+      run: echo "value=hello" >> "$GITHUB_OUTPUT"

--- a/testdata/docs/composite-action-output/fixture.txt
+++ b/testdata/docs/composite-action-output/fixture.txt
@@ -1,0 +1,7 @@
+id=docs-composite-action-output
+source=docs
+mode=supported
+kind=run
+url=https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
+added_at=2026-03-30
+notes=composite action outputs are propagated to steps context

--- a/testdata/docs/composite-action-output/workflow.yml
+++ b/testdata/docs/composite-action-output/workflow.yml
@@ -1,0 +1,10 @@
+name: ci-composite-output
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - id: emit
+        uses: ./.github/actions/emit
+      - id: check
+        run: printf '%s' '${{ steps.emit.outputs.value }}'


### PR DESCRIPTION
## Summary
- Parse `outputs:` section from composite action `action.yml`
- Track output name → inner step output mappings in `ExecutionPlan`
- Apply composite output mappings in executor, copying inner step outputs to outer step ID
- Enables `steps.<composite-action-id>.outputs.*` to work correctly

Closes #18

## Test plan
- [x] New compat test: composite action writes output via `$GITHUB_OUTPUT`, downstream step reads `steps.emit.outputs.value`
- [x] All 676 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)