### PR TITLE
refactor(nix): migrate to flake-parts and extract package.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ nix develop
 }
 ```
 
+### Without flakes
+
+```nix
+# default.nix provides a ready-to-use derivation
+let
+  actrun = import (builtins.fetchTarball "https://github.com/mizchi/actrun/archive/main.tar.gz") { };
+in
+  actrun
+```
+
 ## Quick Start
 
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{
+  pkgs ? import <nixpkgs> { },
+  moonRegistryIndex ? builtins.fetchGit {
+    url = "https://mooncakes.io/git/index";
+    ref = "main";
+  },
+  ...
+}:
+pkgs.callPackage ./package.nix { inherit moonRegistryIndex; }

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774725309,
-        "narHash": "sha256-6A+KPyYuubWS2CW8+0LN1/IMREZR1JA4CKIiwBze1ss=",
-        "owner": "ryoppippi",
+        "lastModified": 1774948263,
+        "narHash": "sha256-5g6Fl5+39UlOjTa+dm9mOTtklHmAr+ai0G9fmq/L+kg=",
+        "owner": "moonbit-community",
         "repo": "moonbit-overlay",
-        "rev": "4ffc0aab45588a519342178cca9231be94c9bab0",
+        "rev": "50118f5c3c0298b5cb17cc6f1c346165801014c8",
         "type": "github"
       },
       "original": {
-        "owner": "ryoppippi",
-        "ref": "fix/moonplatform-bugs",
+        "owner": "moonbit-community",
         "repo": "moonbit-overlay",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "moon-registry": {
       "flake": false,
       "locked": {
@@ -51,6 +69,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1773628058,
@@ -69,6 +102,7 @@
     },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "moon-registry": "moon-registry",
         "moonbit-overlay": "moonbit-overlay",
         "nixpkgs": "nixpkgs_2"

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,9 @@
     let
       supportedSystems = [
         "x86_64-linux"
-        "aarch64-darwin"
+        "aarch64-linux"
         "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);

--- a/flake.nix
+++ b/flake.nix
@@ -23,44 +23,27 @@
 
       flake = {
         overlays.default = _final: prev: {
-          actrun = prev.callPackage (
-            { moonPlatform, ... }:
-            moonPlatform.buildMoonPackage {
-              src = ./.;
-              moonModJson = ./moon.mod.json;
-              moonRegistryIndex = inputs.moon-registry;
-
-              doCheck = false;
-              propagatedBuildInputs = [ prev.git ];
-              nativeBuildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
-            }
-          ) { };
+          actrun = prev.callPackage ./package.nix {
+            moonRegistryIndex = inputs.moon-registry;
+          };
         };
       };
 
       perSystem =
-        { pkgs, system, ... }:
+        { system, ... }:
         let
-          moonPkgs = import inputs.nixpkgs {
+          pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [ inputs.moonbit-overlay.overlays.default ];
             config.allowBroken = true;
           };
 
-          actrun = moonPkgs.moonPlatform.buildMoonPackage {
-            src = ./.;
-            moonModJson = ./moon.mod.json;
+          actrun = pkgs.callPackage ./package.nix {
             moonRegistryIndex = inputs.moon-registry;
-
-            doCheck = false;
-            propagatedBuildInputs = [ moonPkgs.git ];
-            nativeBuildInputs = moonPkgs.lib.optionals moonPkgs.stdenv.isLinux [
-              moonPkgs.autoPatchelfHook
-            ];
           };
 
-          moonHome = moonPkgs.moonPlatform.bundleWithRegistry {
-            cachedRegistry = moonPkgs.moonPlatform.buildCachedRegistry {
+          moonHome = pkgs.moonPlatform.bundleWithRegistry {
+            cachedRegistry = pkgs.moonPlatform.buildCachedRegistry {
               moonModJson = ./moon.mod.json;
               registryIndexSrc = inputs.moon-registry;
             };
@@ -83,13 +66,13 @@
             };
           };
 
-          devShells.default = moonPkgs.mkShellNoCC {
+          devShells.default = pkgs.mkShellNoCC {
             packages = [
               moonHome
-              moonPkgs.git
-              moonPkgs.just
-              moonPkgs.pnpm
-              moonPkgs.nodejs
+              pkgs.git
+              pkgs.just
+              pkgs.pnpm
+              pkgs.nodejs
             ];
             env.MOON_HOME = "${moonHome}";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    # TODO: switch back to "github:moonbit-community/moonbit-overlay" once
-    # https://github.com/moonbit-community/moonbit-overlay/pull/39 is merged
-    moonbit-overlay.url = "github:ryoppippi/moonbit-overlay/fix/moonplatform-bugs";
+    moonbit-overlay.url = "github:moonbit-community/moonbit-overlay";
     moon-registry = {
       url = "git+https://mooncakes.io/git/index";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     moonbit-overlay.url = "github:moonbit-community/moonbit-overlay";
     moon-registry = {
       url = "git+https://mooncakes.io/git/index";
@@ -11,103 +12,87 @@
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      moonbit-overlay,
-      moon-registry,
-    }:
-    let
-      supportedSystems = [
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];
 
-      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      flake = {
+        overlays.default = _final: prev: {
+          actrun = prev.callPackage (
+            { moonPlatform, ... }:
+            moonPlatform.buildMoonPackage {
+              src = ./.;
+              moonModJson = ./moon.mod.json;
+              moonRegistryIndex = inputs.moon-registry;
 
-      pkgsFor =
-        system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ moonbit-overlay.overlays.default ];
-          config.allowBroken = true;
+              doCheck = false;
+              propagatedBuildInputs = [ prev.git ];
+              nativeBuildInputs = prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+            }
+          ) { };
         };
-
-      mkActrun =
-        system:
-        let
-          pkgs = pkgsFor system;
-        in
-        pkgs.moonPlatform.buildMoonPackage {
-          src = ./.;
-          moonModJson = ./moon.mod.json;
-          moonRegistryIndex = moon-registry;
-
-          doCheck = false;
-          propagatedBuildInputs = [ pkgs.git ];
-          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-
-          meta.platforms = supportedSystems;
-        };
-    in
-    {
-      overlays.default = _final: prev: {
-        actrun = mkActrun prev.stdenv.hostPlatform.system;
       };
 
-      packages = forAllSystems (
-        system:
+      perSystem =
+        { pkgs, system, ... }:
         let
-          pkg = mkActrun system;
-        in
-        {
-          default = pkg;
-          actrun = pkg;
-        }
-      );
+          moonPkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ inputs.moonbit-overlay.overlays.default ];
+            config.allowBroken = true;
+          };
 
-      devShells = forAllSystems (
-        system:
-        let
-          pkgs = pkgsFor system;
-          moonHome = pkgs.moonPlatform.bundleWithRegistry {
-            cachedRegistry = pkgs.moonPlatform.buildCachedRegistry {
+          actrun = moonPkgs.moonPlatform.buildMoonPackage {
+            src = ./.;
+            moonModJson = ./moon.mod.json;
+            moonRegistryIndex = inputs.moon-registry;
+
+            doCheck = false;
+            propagatedBuildInputs = [ moonPkgs.git ];
+            nativeBuildInputs = moonPkgs.lib.optionals moonPkgs.stdenv.isLinux [
+              moonPkgs.autoPatchelfHook
+            ];
+          };
+
+          moonHome = moonPkgs.moonPlatform.bundleWithRegistry {
+            cachedRegistry = moonPkgs.moonPlatform.buildCachedRegistry {
               moonModJson = ./moon.mod.json;
-              registryIndexSrc = moon-registry;
+              registryIndexSrc = inputs.moon-registry;
             };
           };
         in
         {
-          default = pkgs.mkShellNoCC {
+          packages = {
+            default = actrun;
+            inherit actrun;
+          };
+
+          apps = {
+            default = {
+              type = "app";
+              program = "${actrun}/bin/actrun";
+            };
+            actrun = {
+              type = "app";
+              program = "${actrun}/bin/actrun";
+            };
+          };
+
+          devShells.default = moonPkgs.mkShellNoCC {
             packages = [
               moonHome
-              pkgs.git
-              pkgs.just
-              pkgs.pnpm
-              pkgs.nodejs
+              moonPkgs.git
+              moonPkgs.just
+              moonPkgs.pnpm
+              moonPkgs.nodejs
             ];
             env.MOON_HOME = "${moonHome}";
           };
-        }
-      );
-
-      apps = forAllSystems (
-        system:
-        let
-          pkg = mkActrun system;
-        in
-        {
-          default = {
-            type = "app";
-            program = "${pkg}/bin/actrun";
-          };
-          actrun = {
-            type = "app";
-            program = "${pkg}/bin/actrun";
-          };
-        }
-      );
+        };
     };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  git,
+  autoPatchelfHook,
+  stdenv,
+  moonPlatform,
+  moonRegistryIndex,
+}:
+moonPlatform.buildMoonPackage {
+  src = ./.;
+  moonModJson = ./moon.mod.json;
+  inherit moonRegistryIndex;
+
+  doCheck = false;
+  propagatedBuildInputs = [ git ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  meta = {
+    description = "Run GitHub Actions locally";
+    homepage = "https://github.com/mizchi/actrun";
+    mainProgram = "actrun";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Switch moonbit-overlay back to the official upstream (`moonbit-community/moonbit-overlay`)
- Add `aarch64-linux` to supported systems
- Migrate flake from hand-rolled `forAllSystems`/`genAttrs` to `flake-parts` `mkFlake`
- Extract build derivation into `package.nix` and add `default.nix` for non-flake consumers
- Update README with non-flake usage example

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix build` succeeds