### PR TITLE
fix: handle missing native commands

### DIFF
--- a/src/cmd/actrun/main_wbtest.mbt
+++ b/src/cmd/actrun/main_wbtest.mbt
@@ -1413,6 +1413,22 @@ test "cli: parse run view with --exit-status" {
 }
 
 ///|
+#cfg(target="native")
+async test "cli: run_command reports missing command without aborting" {
+  let (code, stdout, stderr) = run_command(
+    "__actrun_missing_command_for_test__",
+    [],
+    cwd=".",
+  )
+  inspect(code, content="-1")
+  inspect(stdout, content="")
+  inspect(
+    stderr,
+    content="failed to run command: __actrun_missing_command_for_test__",
+  )
+}
+
+///|
 test "cli: run_view_exit_code returns 0 for success" {
   let json = "{\"conclusion\": \"success\", \"status\": \"completed\"}"
   inspect(run_view_exit_code(json), content="0")

--- a/src/cmd/actrun/process_native.mbt
+++ b/src/cmd/actrun/process_native.mbt
@@ -5,6 +5,12 @@ async fn run_command(
   args : Array[String],
   cwd? : String = ".",
 ) -> (Int, String, String) {
-  let (code, stdout, stderr) = @process.collect_output(cmd, args, cwd~)
+  let (code, stdout, stderr) = try
+    @process.collect_output(cmd, args, cwd~)
+  catch {
+    _ => return (-1, "", "failed to run command: " + cmd)
+  } noraise {
+    value => value
+  }
   (code, stdout.text(), stderr.text())
 }


### PR DESCRIPTION
## Summary
- return a non-zero command result when native command spawning fails
- keep optional doctor checks from aborting when an optional binary is missing
- add a native regression test for missing commands

## Validation
- `moon fmt --check`
- `moon build src/cmd/actrun --target native`
- `moon test src/cmd/actrun/main_wbtest.mbt --target native --filter '*missing command*'`
- `_build/native/debug/build/cmd/actrun/actrun.exe doctor`

## Notes
- `moon check --deny-warn --target native` currently fails on existing deprecation warnings with the installed MoonBit toolchain
- `moon test --target native src/cmd/actrun` currently fails on existing inspect snapshot formatting differences with the installed MoonBit toolchain
