### PR TITLE
test: strip absolute repo root from expect snapshots

### DIFF
--- a/.github/actions/wasi-node-sidecar/dist/package.json
+++ b/.github/actions/wasi-node-sidecar/dist/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774948263,
-        "narHash": "sha256-5g6Fl5+39UlOjTa+dm9mOTtklHmAr+ai0G9fmq/L+kg=",
+        "lastModified": 1779775885,
+        "narHash": "sha256-oxSxoHsGiXGnB5nTw4bUB2cowT0SM/UGOZABi1PWRYI=",
         "owner": "moonbit-community",
         "repo": "moonbit-overlay",
-        "rev": "50118f5c3c0298b5cb17cc6f1c346165801014c8",
+        "rev": "d7386bab18d2b4844292f335afbc9ee67af39538",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742272065,
-        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
+        "lastModified": 1775639890,
+        "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
+        "rev": "456e8a9468b9d46bd8c9524425026c00745bc4d2",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,0 +1,28 @@
+{
+  "name": "mizchi/actrun",
+  "version": "0.30.0",
+  "deps": {
+    "moonbitlang/async": "0.16.6",
+    "mizchi/bitflow": "0.4.0",
+    "mizchi/bit": "0.39.2",
+    "moonbitlang/x": "0.4.40",
+    "moonbitlang/quickcheck": "0.9.10",
+    "moonbit-community/yaml": "0.0.4",
+    "mizchi/moomaid": "0.1.2",
+    "bobzhang/toml": "0.1.8",
+    "mizchi/jq": "0.2.1",
+    "mizchi/wite": "0.11.0"
+  },
+  "readme": "src/README.mbt.md",
+  "repository": "https://github.com/mizchi/actrun",
+  "license": "Apache-2.0",
+  "keywords": [
+    "github-actions",
+    "workflow",
+    "runner",
+    "ci"
+  ],
+  "description": "MVP GitHub Actions-compatible push CI runner with bitflow lowering, native execution, and bit workspace materialization.",
+  "source": "src",
+  "preferred-target": "native"
+}

--- a/src/compat_docs_test.mbt
+++ b/src/compat_docs_test.mbt
@@ -654,7 +654,9 @@ async test "compat docs: job container fixture executes run step via docker adap
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/out.txt")),
+    executor_test_strip_repo_root(
+      @xfs.read_file_to_string(workspace + "/out.txt"),
+    ),
     content=(
       #|"from-container|<repo>/_build/test-compat-docs-workspaces/job-container-basic/nested"
     ),

--- a/src/compat_docs_test.mbt
+++ b/src/compat_docs_test.mbt
@@ -654,9 +654,9 @@ async test "compat docs: job container fixture executes run step via docker adap
     ),
   )
   @debug.debug_inspect(
-    @xfs.read_file_to_string(workspace + "/out.txt"),
+    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/out.txt")),
     content=(
-      #|"from-container|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-compat-docs-workspaces/job-container-basic/nested"
+      #|"from-container|<repo>/_build/test-compat-docs-workspaces/job-container-basic/nested"
     ),
   )
   @debug.debug_inspect(
@@ -2590,9 +2590,9 @@ async test "compat docs: github context is available in step script" {
     ),
   )
   @debug.debug_inspect(
-    task.stdout,
+    executor_test_strip_repo_root(task.stdout),
     content=(
-      #|"<github-context|build|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-compat-docs-workspaces/context-github-script>"
+      #|"<github-context|build|<repo>/_build/test-compat-docs-workspaces/context-github-script>"
     ),
   )
 }

--- a/src/executor_test.mbt
+++ b/src/executor_test.mbt
@@ -1780,7 +1780,9 @@ async test "executor: cached github repo composite action runs inner steps" {
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
+    executor_test_strip_repo_root(
+      verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    ),
     content=(
       #|"write|mizchi-test/demo-action|v1|write|<repo>/_build/actrun/github_actions/mizchi-test/demo-action/v1/composite"
     ),
@@ -1843,7 +1845,9 @@ async test "executor: cached github repo node action runs main entrypoint" {
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
+    executor_test_strip_repo_root(
+      verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    ),
     content=(
       #|"from-input|mizchitestnodeactionaction|<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action|mizchi-test/node-action|v1"
     ),
@@ -1908,7 +1912,9 @@ async test "executor: job container runs github repo node action via docker adap
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/node.txt")),
+    executor_test_strip_repo_root(
+      @xfs.read_file_to_string(workspace + "/node.txt"),
+    ),
     content=(
       #|"from-container|<repo>/_build/test-workspaces/executor-job-container-node-action|<repo>/_build/actrun/github_actions/mizchi-test/node-action-container/v1/action"
     ),
@@ -3632,7 +3638,9 @@ async test "executor: local composite action runs inner steps" {
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
+    executor_test_strip_repo_root(
+      verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    ),
     content=(
       #|"from-local-action|<repo>/_build/test-workspaces/executor-local-action/.github/actions/setup"
     ),
@@ -3866,7 +3874,9 @@ async test "executor: github action_path context is available in local composite
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/action-path.txt")),
+    executor_test_strip_repo_root(
+      @xfs.read_file_to_string(workspace + "/action-path.txt"),
+    ),
     content=(
       #|"<repo>/_build/test-workspaces/executor-local-action-github-action-path/.github/actions/setup"
     ),
@@ -5380,7 +5390,9 @@ async test "executor: job container runs run steps via docker adapter" {
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(expect_task_report(report, "build/show").stdout),
+    executor_test_strip_repo_root(
+      expect_task_report(report, "build/show").stdout,
+    ),
     content=(
       #|"from-container|from-step|<repo>/_build/test-workspaces/executor-job-container/nested"
     ),
@@ -5755,7 +5767,9 @@ async test "executor: github repo node action lifecycle shares GITHUB_STATE acro
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/post.txt")),
+    executor_test_strip_repo_root(
+      @xfs.read_file_to_string(workspace + "/post.txt"),
+    ),
     content=(
       #|"main|<repo>/_build/test-workspaces/executor-github-node-lifecycle"
     ),
@@ -5833,7 +5847,9 @@ async test "executor: github repo docker action lifecycle shares GITHUB_STATE ac
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/post.txt")),
+    executor_test_strip_repo_root(
+      @xfs.read_file_to_string(workspace + "/post.txt"),
+    ),
     content=(
       #|"main|<repo>/_build/test-workspaces/executor-github-docker-lifecycle"
     ),

--- a/src/executor_test.mbt
+++ b/src/executor_test.mbt
@@ -6,6 +6,18 @@ fn ensure_dir(path : String) -> Unit raise {
 }
 
 ///|
+/// Replace the runner's cwd prefix with the placeholder `<repo>` so
+/// expect snapshots stay machine-independent. Without this, expect
+/// strings bake in the developer's local absolute path
+/// (e.g. `/Users/me/ghq/github.com/mizchi/actrun/...`) and break on
+/// CI / other machines.
+fn executor_test_strip_repo_root(s : String) -> String {
+  let cwd = @xsys.get_env_var("PWD").unwrap_or(".")
+  let prefix = if cwd.has_suffix("/") { cwd } else { cwd + "/" }
+  s.replace_all(old=prefix, new="<repo>/")
+}
+
+///|
 fn executor_test_absolute_path(path : String) -> String {
   if path.has_prefix("/") {
     return path
@@ -563,9 +575,9 @@ async test "executor: injects basic github runner env" {
     ),
   )
   @debug.debug_inspect(
-    task.stdout,
+    executor_test_strip_repo_root(task.stdout),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-github-env|ci|build|true|true"
+      #|"<repo>/_build/test-workspaces/executor-github-env|ci|build|true|true"
     ),
   )
 }
@@ -1768,9 +1780,9 @@ async test "executor: cached github repo composite action runs inner steps" {
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
     content=(
-      #|"write|mizchi-test/demo-action|v1|write|/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/demo-action/v1/composite"
+      #|"write|mizchi-test/demo-action|v1|write|<repo>/_build/actrun/github_actions/mizchi-test/demo-action/v1/composite"
     ),
   )
 }
@@ -1831,9 +1843,9 @@ async test "executor: cached github repo node action runs main entrypoint" {
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
     content=(
-      #|"from-input|mizchitestnodeactionaction|/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/node-action/v1/action|mizchi-test/node-action|v1"
+      #|"from-input|mizchitestnodeactionaction|<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action|mizchi-test/node-action|v1"
     ),
   )
   let node_log = @xfs.read_file_to_string(node_log_path)
@@ -1896,9 +1908,9 @@ async test "executor: job container runs github repo node action via docker adap
     ),
   )
   @debug.debug_inspect(
-    @xfs.read_file_to_string(workspace + "/node.txt"),
+    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/node.txt")),
     content=(
-      #|"from-container|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-job-container-node-action|/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/node-action-container/v1/action"
+      #|"from-container|<repo>/_build/test-workspaces/executor-job-container-node-action|<repo>/_build/actrun/github_actions/mizchi-test/node-action-container/v1/action"
     ),
   )
   let docker_log = @xfs.read_file_to_string(docker_log_path)
@@ -3613,16 +3625,16 @@ async test "executor: local composite action runs inner steps" {
   )
   let show = expect_task_report(report, "build/setup__show")
   @debug.debug_inspect(
-    show.stdout.trim(chars=" \n\r\t").to_owned(),
+    executor_test_strip_repo_root(show.stdout.trim(chars=" \n\r\t").to_owned()),
     content=(
-      #|"from-local-action|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-local-action/.github/actions/setup"
+      #|"from-local-action|<repo>/_build/test-workspaces/executor-local-action/.github/actions/setup"
     ),
   )
   let verify = expect_task_report(report, "build/verify")
   @debug.debug_inspect(
-    verify.stdout.trim(chars=" \n\r\t").to_owned(),
+    executor_test_strip_repo_root(verify.stdout.trim(chars=" \n\r\t").to_owned()),
     content=(
-      #|"from-local-action|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-local-action/.github/actions/setup"
+      #|"from-local-action|<repo>/_build/test-workspaces/executor-local-action/.github/actions/setup"
     ),
   )
 }
@@ -3854,9 +3866,9 @@ async test "executor: github action_path context is available in local composite
     ),
   )
   @debug.debug_inspect(
-    @xfs.read_file_to_string(workspace + "/action-path.txt"),
+    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/action-path.txt")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-local-action-github-action-path/.github/actions/setup"
+      #|"<repo>/_build/test-workspaces/executor-local-action-github-action-path/.github/actions/setup"
     ),
   )
 }
@@ -5368,9 +5380,9 @@ async test "executor: job container runs run steps via docker adapter" {
     ),
   )
   @debug.debug_inspect(
-    expect_task_report(report, "build/show").stdout,
+    executor_test_strip_repo_root(expect_task_report(report, "build/show").stdout),
     content=(
-      #|"from-container|from-step|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-job-container/nested"
+      #|"from-container|from-step|<repo>/_build/test-workspaces/executor-job-container/nested"
     ),
   )
   let docker_log = @xfs.read_file_to_string(docker_log_path)
@@ -5743,9 +5755,9 @@ async test "executor: github repo node action lifecycle shares GITHUB_STATE acro
     ),
   )
   @debug.debug_inspect(
-    @xfs.read_file_to_string(workspace + "/post.txt"),
+    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/post.txt")),
     content=(
-      #|"main|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-github-node-lifecycle"
+      #|"main|<repo>/_build/test-workspaces/executor-github-node-lifecycle"
     ),
   )
 }
@@ -5821,9 +5833,9 @@ async test "executor: github repo docker action lifecycle shares GITHUB_STATE ac
     ),
   )
   @debug.debug_inspect(
-    @xfs.read_file_to_string(workspace + "/post.txt"),
+    executor_test_strip_repo_root(@xfs.read_file_to_string(workspace + "/post.txt")),
     content=(
-      #|"main|/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/executor-github-docker-lifecycle"
+      #|"main|<repo>/_build/test-workspaces/executor-github-docker-lifecycle"
     ),
   )
 }

--- a/src/lib_test.mbt
+++ b/src/lib_test.mbt
@@ -948,7 +948,9 @@ test "lowering: custom registry node action resolves backend from manifest" {
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(setup_plan.action.unwrap().entrypoint.unwrap_or("")),
+    executor_test_strip_repo_root(
+      setup_plan.action.unwrap().entrypoint.unwrap_or(""),
+    ),
     content=(
       #|"<repo>/_build/test-workspaces/custom-registry-node-root/bit/std/cache/v1/index.sh"
     ),
@@ -1685,13 +1687,17 @@ test "lowering: cached github repo node action becomes node task" {
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(remote_plan.action.unwrap().entrypoint.unwrap_or("")),
+    executor_test_strip_repo_root(
+      remote_plan.action.unwrap().entrypoint.unwrap_or(""),
+    ),
     content=(
       #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action/main.sh"
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(remote_plan.action.unwrap().action_path.unwrap_or("")),
+    executor_test_strip_repo_root(
+      remote_plan.action.unwrap().action_path.unwrap_or(""),
+    ),
     content=(
       #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
     ),
@@ -1715,7 +1721,9 @@ test "lowering: cached github repo node action becomes node task" {
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(remote_plan.env.get("GITHUB_ACTION_PATH").unwrap_or("")),
+    executor_test_strip_repo_root(
+      remote_plan.env.get("GITHUB_ACTION_PATH").unwrap_or(""),
+    ),
     content=(
       #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
     ),
@@ -1832,7 +1840,9 @@ test "lowering: cached github repo docker action becomes docker task" {
     ),
   )
   @debug.debug_inspect(
-    executor_test_strip_repo_root(remote_plan.action.unwrap().image.unwrap_or("")),
+    executor_test_strip_repo_root(
+      remote_plan.action.unwrap().image.unwrap_or(""),
+    ),
     content=(
       #|"<repo>/_build/actrun/github_actions/mizchi-test/docker-action/v1/action/Dockerfile"
     ),

--- a/src/lib_test.mbt
+++ b/src/lib_test.mbt
@@ -948,9 +948,9 @@ test "lowering: custom registry node action resolves backend from manifest" {
     ),
   )
   @debug.debug_inspect(
-    setup_plan.action.unwrap().entrypoint.unwrap_or(""),
+    executor_test_strip_repo_root(setup_plan.action.unwrap().entrypoint.unwrap_or("")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/custom-registry-node-root/bit/std/cache/v1/index.sh"
+      #|"<repo>/_build/test-workspaces/custom-registry-node-root/bit/std/cache/v1/index.sh"
     ),
   )
   @debug.debug_inspect(
@@ -1685,15 +1685,15 @@ test "lowering: cached github repo node action becomes node task" {
     ),
   )
   @debug.debug_inspect(
-    remote_plan.action.unwrap().entrypoint.unwrap_or(""),
+    executor_test_strip_repo_root(remote_plan.action.unwrap().entrypoint.unwrap_or("")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/node-action/v1/action/main.sh"
+      #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action/main.sh"
     ),
   )
   @debug.debug_inspect(
-    remote_plan.action.unwrap().action_path.unwrap_or(""),
+    executor_test_strip_repo_root(remote_plan.action.unwrap().action_path.unwrap_or("")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
+      #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
     ),
   )
   @debug.debug_inspect(
@@ -1715,9 +1715,9 @@ test "lowering: cached github repo node action becomes node task" {
     ),
   )
   @debug.debug_inspect(
-    remote_plan.env.get("GITHUB_ACTION_PATH").unwrap_or(""),
+    executor_test_strip_repo_root(remote_plan.env.get("GITHUB_ACTION_PATH").unwrap_or("")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
+      #|"<repo>/_build/actrun/github_actions/mizchi-test/node-action/v1/action"
     ),
   )
 }
@@ -1832,9 +1832,9 @@ test "lowering: cached github repo docker action becomes docker task" {
     ),
   )
   @debug.debug_inspect(
-    remote_plan.action.unwrap().image.unwrap_or(""),
+    executor_test_strip_repo_root(remote_plan.action.unwrap().image.unwrap_or("")),
     content=(
-      #|"/Users/mz/ghq/github.com/mizchi/actrun/_build/actrun/github_actions/mizchi-test/docker-action/v1/action/Dockerfile"
+      #|"<repo>/_build/actrun/github_actions/mizchi-test/docker-action/v1/action/Dockerfile"
     ),
   )
   @debug.debug_inspect(


### PR DESCRIPTION
PR #36 が無事 merge されたものの、 main の CI で 14 件のテストが失敗。 原因は \`executor_test.mbt\` / \`lib_test.mbt\` / \`compat_docs_test.mbt\` の \`debug_inspect\` の expect 文字列に開発者のローカル絶対パスがハードコードされていたこと。

\`\`\`diff
-\"/Users/mz/ghq/github.com/mizchi/actrun/_build/test-workspaces/...\"
+\"/home/runner/work/actrun/actrun/_build/test-workspaces/...\"
\`\`\`

## 修正内容

- \`executor_test_strip_repo_root(s)\` helper を追加: \`\$PWD\` prefix を placeholder \`<repo>\` に置換
- 17 箇所の \`debug_inspect\` の第一引数を helper でラップ
- 該当する expect content を \`<repo>/_build/...\` に書き換え

## 影響範囲

- \`src/executor_test.mbt\`: 10 箇所
- \`src/lib_test.mbt\`: 5 箇所
- \`src/compat_docs_test.mbt\`: 2 箇所

## 残課題 (本 PR の scope 外)

- \`nix-build\` / \`compat-wasi-gha\` も fail していた; rate-limit でログ取れず、 同じ path 問題なのか別問題かは未確認。 この PR の CI で同じパターンか別かが判明する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)